### PR TITLE
Nicer pep number matching and extraction

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -295,18 +295,12 @@ def cmd_uptime(match: Match[str]) -> Response:
     return UptimeResponse()
 
 
-@handle_message('!pep')
+@handle_message('!pep[ ]?(?P<pep_num>\d{1,4})')
 def cmd_pep(match: Match[str]) -> Response:
-    *_, msg = match.groups()
-    *_, rest = msg.partition(' ')
-    try:
-        pep = str(int(rest)).zfill(4)
-    except ValueError:
-        return MessageResponse(match, 'Please make sure you gave me a number!')
-    else:
-        return MessageResponse(
-            match, f'https://www.python.org/dev/peps/pep-{pep}/',
-        )
+    *_, number = match.groups()
+    return MessageResponse(
+        match, f'https://www.python.org/dev/peps/pep-{number.zfill(4)}/',
+    )
 
 
 COMMAND_RE = re.compile(r'!\w+')

--- a/bot.py
+++ b/bot.py
@@ -299,7 +299,7 @@ def cmd_uptime(match: Match[str]) -> Response:
 def cmd_pep(match: Match[str]) -> Response:
     *_, number = match.groups()
     return MessageResponse(
-        match, f'https://www.python.org/dev/peps/pep-{number.zfill(4)}/',
+        match, f'https://www.python.org/dev/peps/pep-{int(number).zfill(4)}/',
     )
 
 

--- a/bot.py
+++ b/bot.py
@@ -295,7 +295,7 @@ def cmd_uptime(match: Match[str]) -> Response:
     return UptimeResponse()
 
 
-@handle_message('!pep[ ]?(?P<pep_num>\d{1,4})')
+@handle_message(r'!pep[ ]?(?P<pep_num>\d{1,4})')
 def cmd_pep(match: Match[str]) -> Response:
     *_, number = match.groups()
     return MessageResponse(

--- a/bot.py
+++ b/bot.py
@@ -295,11 +295,11 @@ def cmd_uptime(match: Match[str]) -> Response:
     return UptimeResponse()
 
 
-@handle_message(r'!pep[ ]?(?P<pep_num>\d{1,4})')
+@handle_message(r'!pep[ ]?(?P<pep_num>\d{1,4})', flags=re.ASCII)
 def cmd_pep(match: Match[str]) -> Response:
     *_, number = match.groups()
     return MessageResponse(
-        match, f'https://www.python.org/dev/peps/pep-{int(number).zfill(4)}/',
+        match, f'https://www.python.org/dev/peps/pep-{number.zfill(4)}/',
     )
 
 


### PR DESCRIPTION
Covers the following cases:
!pep 1234 test
!pep 1234test
!pep1234 test
!pep1245test
!pep test
!pep

[RegEx101 example](https://regex101.com/r/2xIVQb/1)