### PR TITLE
Add ability to search YouTube playlists and insert links to videos to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ and this felt like a decent project to dive in on.
      "username": "...",
      "channel": "...",
      "oauth_token": "...",
-     "client_id": "..."
+     "client_id": "...",
+     "youtube_api_key": "...",
+     "youtube_playlists": {
+       "explains": "PLWBKAf81pmOaP9naRiNAqug6EBnkPakvY",
+       "faq": "PLWBKAf81pmOZEPeIV2_pIESK5hRMAo1hR"
+      }
    }
    ```
 
@@ -24,18 +29,21 @@ and this felt like a decent project to dive in on.
      the streamer's channel name
    - `oauth_token`: follow the directions [here][docs-irc] to get a token
    - `client_id`: set up an application for your chat bot [here][app-setup]
+   - `youtube_api_key`: set up an API key for a YouTube account to fetch playlist videos [here][youtube-setup]
+   - `youtube_playlists`: a dictionary of YouTube playlists that can be searched via commands
 
-1. Use python3.7 or newer and install `aiohttp`
+1. Use python3.7 or newer and install the dependencies in `requirements.txt`
 
    ```bash
    virtualenv venv -ppython3.7
-   venv/bin/pip install aiohttp
+   venv/bin/pip install -r requirements.txt
    ```
 
 1. Run! `venv/bin/python bot.py`
 
 [docs-irc]: https://dev.twitch.tv/docs/irc/
 [app-setup]: https://dev.twitch.tv/docs/authentication/#registration
+[youtube-setup]: https://console.developers.google.com/apis/credentials
 
 ## implemented commands
 


### PR DESCRIPTION
Allow config.json to take a dictionary of YouTube playlist IDs (and YouTube API key)
Extend `!explains` and `!faq` to take one or more search terms
Fetch list of videos in playlist via API and store in a virtual sqlite table
Use sqlite full-text search to provide a flexible search tool for looking up videos
Perform API fetch and sqlite DB inserts once per bot run
Add `!explainlist` to provide original behaviour of linking to GitHub wiki page

Fixes #29