### PR TITLE
update keyboard faq link

### DIFF
--- a/bot/plugins/simple.py
+++ b/bot/plugins/simple.py
@@ -59,7 +59,7 @@ _TEXT_COMMANDS: Tuple[Tuple[str, str], ...] = (
         '(contributed by PhillipWei): https://amzn.to/3jzmwh3 '
         'or '
         '(split) awcKeebL awcKeebR kinesis freestyle pro (cherry mx reds) '
-        'https://amzn.to/3jyN4PC (faq: https://youtu.be/DZgCUWf9DZM)',
+        'https://amzn.to/3jyN4PC (faq: https://youtu.be/DZgCUWf9DZM )',
     ),
     (
         '!keyboard2',


### PR DESCRIPTION
I noticed Twitch added a `)` to the youtube link in the faq section of the `!keyboard` command, so that part of the bot's response looks like

(faq: [https://youtu.be/DZgCUWf9DZM)](https://youtu.be/DZgCUWf9DZM\))

(at least on mobile) which resulted in a 404. This PR hopefully corrects that.