### PR TITLE
seconds_to_readable grammar fix

### DIFF
--- a/bot/util.py
+++ b/bot/util.py
@@ -5,14 +5,22 @@ from typing import Generator
 from typing import IO
 
 
+def get_quantified_unit(unit: str, amount: int) -> str:
+    if amount == 1:
+        return unit
+    else:
+        return f'{unit}s'
+
+
 def seconds_to_readable(seconds: int) -> str:
     parts = []
     for n, unit in (
-            (60 * 60, 'hours'),
-            (60, 'minutes'),
-            (1, 'seconds'),
+            (60 * 60, 'hour'),
+            (60, 'minute'),
+            (1, 'second'),
     ):
         if seconds // n:
+            unit = get_quantified_unit(unit, seconds // n)
             parts.append(f'{seconds // n} {unit}')
         seconds %= n
     return ', '.join(parts)


### PR DESCRIPTION
Fixed the `seconds_to_readable` function to output grammatically correct units.

i.e. non-plural quantities are no longer represented with plural units.