### PR TITLE
Suggest similar commands if there's no exact match

### DIFF
--- a/bot/data.py
+++ b/bot/data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import difflib
 import pkgutil
 import re
 from typing import Awaitable
@@ -157,7 +158,15 @@ async def cmd_help(config: Config, match: Match[str]) -> str:
     possible_cmds.update(COMMANDS)
     possible_cmds.difference_update(SECRET_CMDS)
     commands = ['!help'] + sorted(possible_cmds)
-    msg = f'possible commands: {", ".join(commands)}'
-    if not match['msg'].startswith('!help'):
-        msg = f'unknown command ({esc(match["msg"].split()[0])}), {msg}'
+
+    cmd = match['msg'].split()[0]
+    if cmd.startswith('!help'):
+        msg = f' possible commands: {", ".join(commands)}'
+    else:
+        msg = f'unknown command ({esc(cmd)}).'
+        suggestions = difflib.get_close_matches(cmd, commands, cutoff=0.7)
+        if suggestions:
+            msg += f' did you mean: {", ".join(suggestions)}?'
+        else:
+            msg += f' possible commands: {", ".join(commands)}'
     return format_msg(match, msg)


### PR DESCRIPTION
In the current implementation, it will show max. 3 suggestions and only if a suggestion has 70% similarity or higher.
This can be tweaked or moved to the bot configuration file, if needed.

**Examples**

There are several 70% matches, we show 3 as expected
>**Senpos**: !keybord
**Bot**: unknown command (!keybord). did you mean: !keyboard, !keyboard3, !keyboard2?

A single match was found
>**Senpos**: !ohaio
**Bot**: unknown command (!ohaio). did you mean: !ohai?

No matches were found, show all commands as a fallback
>**Senpos**: !hellohello123
**Bot**: unknown command (!hellohello123). possible commands: !help, !bonk, !bonkedrank, !bonkrank, !bot, !chatplot, !chatrank, !copilot, !discord, !distro, !donate, !editor, !emotes, !explain, !faq, !followage, !github, !job, !joke, !keyboard, !keyboard2, !keyboard3, !lurk, !motd, !ohai, !pep, !playlist, !speechless, !still, !support, !theme, !today, !top10chat, !top5bonked, !top5bonkers, !twitter, !uptime, !youtube

It uses `difflib.get_close_matches` which is probably not ideal here, but should be good enough/better than nothing. Other option is to use something like [editdistance-s](https://pypi.org/project/editdistance-s/)? 🤷 

While the code is straightforward, thanks to [click-didyoumean](https://github.com/click-contrib/click-didyoumean) (MIT licensed) for the idea