### PR TITLE
Add `!!` to call last working message in `get_handler`

### DIFF
--- a/bot/data.py
+++ b/bot/data.py
@@ -109,6 +109,7 @@ def periodic_handler(*, seconds: int) -> Callable[[Callback], Callback]:
 
 
 def get_handler(msg: str) -> tuple[Callback, Match[str]] | None:
+    prev_cmd: str | None = None
     msg_match = MSG_RE.match(msg)
     if msg_match:
         info = parse_badge_info(msg_match['info'])
@@ -123,7 +124,10 @@ def get_handler(msg: str) -> tuple[Callback, Match[str]] | None:
         if cmd_match:
             command = f'!{cmd_match["cmd"].lstrip("!").lower()}'
             if command in COMMANDS:
+                prev_cmd = msg_match['msg']
                 return COMMANDS[command], msg_match
+        elif msg_match['msg'] == '!!' and prev_cmd is not None:
+            return get_handler(msg_match.string.replace('!!', prev_cmd))
 
     for pattern, handler in HANDLERS:
         match = pattern.match(msg)


### PR DESCRIPTION
If I did this right, it closes issue #34 :D 

Setting
```py
prev_msg = '@badges=;bits=0;color=;display-name=username :username PRIVMSG #anthonyrwxcode :!ohai\r\n'
```
...then running
```sh
$ PYTHONPATH=. python bot --test '!!'
[02:49]<username> !!
[02:49]<anthbot>  ohai, username!
```
calls the `!ohai` since it was the previous message!

I was worried about it getting stuck in some recursive loop, but `prev_msg` will only be set to `None`, or a command found in `COMMANDS`. So in the previous example, a user typing `!!` will call `!ohai`, which stores `!ohai` as the previous message again.

Yay!