### PR TITLE
Make follow age day-precise

### DIFF
--- a/bot/plugins/followage.py
+++ b/bot/plugins/followage.py
@@ -86,8 +86,19 @@ async def cmd_followage(config: Config, match: Match[str]) -> str:
         follow_age['followed_at'].rstrip('Z'),
     )
     delta = now - date_of_follow
+
+    if delta <= datetime.timedelta(days=2):
+        # using 2 days because precisedelta returns "1 days"
+        humanize_string = humanize.naturaldelta(delta)
+    else:
+        humanize_string = humanize.precisedelta(
+            delta,
+            minimum_unit='days',
+            format='%d',
+        )
+        humanize_string = humanize_string.replace(' 1 days', ' 1 day')
     return format_msg(
         match,
         f'{esc(follow_age["from_name"])} has been following for '
-        f'{esc(humanize.naturaldelta(delta))}!',
+        f'{esc(humanize_string)}!',
     )

--- a/bot/plugins/followage.py
+++ b/bot/plugins/followage.py
@@ -92,7 +92,7 @@ async def cmd_followage(config: Config, match: Match[str]) -> str:
         humanize_string = humanize.naturaldelta(delta)
     else:
         humanize_string = humanize.precisedelta(
-            delta,
+            datetime.timedelta(days=delta.days),
             minimum_unit='days',
             format='%d',
         )


### PR DESCRIPTION
This makes the follow age output precise to the day rather than whatever the default is for humanize, which by the way will always return `"1 days"` if it's after the month threshold, which is dumb...but I guess I get it, could use a `.replace(" 1 days", " 1 day")` but I'm not sure I love that.