### PR TITLE
Add user aliases

### DIFF
--- a/bot/plugins/chatrank.py
+++ b/bot/plugins/chatrank.py
@@ -29,8 +29,9 @@ BONKER_RE = re.compile(r'^\[[^]]+\][^<*]*<(?P<chat_user>[^>]+)> !bonk\b')
 BONKED_RE = re.compile(r'^\[[^]]+\][^<*]*<[^>]+> !bonk @?(?P<chat_user>\w+)')
 
 USER_ALIASES = {
-    'kevinsjoberg': 'kmjao'
+    'kevinsjoberg': 'kmjao',
 }
+
 
 @functools.lru_cache(maxsize=None)
 def _counts_per_file(filename: str, reg: Pattern[str]) -> Mapping[str, int]:

--- a/bot/plugins/chatrank.py
+++ b/bot/plugins/chatrank.py
@@ -28,6 +28,9 @@ CHAT_LOG_RE = re.compile(
 BONKER_RE = re.compile(r'^\[[^]]+\][^<*]*<(?P<chat_user>[^>]+)> !bonk\b')
 BONKED_RE = re.compile(r'^\[[^]]+\][^<*]*<[^>]+> !bonk @?(?P<chat_user>\w+)')
 
+USER_ALIASES = {
+    'kevinsjoberg': 'kmjao'
+}
 
 @functools.lru_cache(maxsize=None)
 def _counts_per_file(filename: str, reg: Pattern[str]) -> Mapping[str, int]:
@@ -40,7 +43,9 @@ def _counts_per_file(filename: str, reg: Pattern[str]) -> Mapping[str, int]:
                 continue
             user = match['chat_user'] or match['action_user']
             assert user, line
-            counts[user.lower()] += 1
+
+            lowercase_user = user.lower()
+            counts[USER_ALIASES.get(lowercase_user, lowercase_user)] += 1
     return counts
 
 


### PR DESCRIPTION
Twitch users may change their nickname. By keeping a dict of previously
known aliases we ensure their previously accumulated chatrank is taken
into account.